### PR TITLE
Harden Railway observability and CI smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,8 @@ jobs:
       - name: Run tests
         run: |
           python -m unittest discover -s tests -p "test_*.py" -v
+
+      - name: Run production observability smoke check
+        if: github.event_name == 'push' && (github.ref_name == 'master' || github.ref_name == 'main')
+        run: |
+          python scripts/monitor_deploy.py --url "https://geofeedback.cl" --once --retries 6 --retry-delay 10

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - `scripts/monitor_deploy.py` ya no depende de `requests`: usa librería estándar, URL configurable y modo `--once` para smoke checks.
 - UX de rutas mejorada: `/api` redirige a `/api/docs` y `/contact` redirige a `/#contacto`.
 - Bootstrap de base de datos en Railway actualizado para crear tablas de analytics (`06_create_analytics_tables.sql`).
-- Pipeline de CI reforzado con regresión dedicada de observability y validación de la CLI de monitoreo en `.github/workflows/ci.yml`.
+- Pipeline de CI reforzado con regresión dedicada de observability, validación de la CLI de monitoreo y smoke check contra el deployment productivo en `.github/workflows/ci.yml`.
 
 ---
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -59,7 +59,7 @@ CMD ["sh", "-c", "gunicorn \
     --threads 2 \
     --timeout 120 \
     --preload \
-    --access-logfile - \
-    --error-logfile - \
+    --access-logfile /dev/stdout \
+    --error-logfile /dev/stdout \
     --log-level info \
     app:app"]

--- a/api/app.py
+++ b/api/app.py
@@ -14,6 +14,7 @@ import time
 import hashlib
 import threading
 import logging
+import sys
 from collections import defaultdict
 import redis
 from flask import Flask, jsonify, request, redirect, Response
@@ -114,7 +115,7 @@ logger = logging.getLogger('geofeedback')
 logger.setLevel(logging.INFO)
 # Configurar formato nativo para mejor integración con Loki
 formatter = logging.Formatter('%(message)s')
-ch = logging.StreamHandler()
+ch = logging.StreamHandler(sys.stdout)
 ch.setFormatter(formatter)
 if not logger.handlers:
     logger.addHandler(ch)
@@ -211,6 +212,50 @@ def get_client_ip():
 
 # Inicializar Google Earth Engine
 gee_initialized = init_gee()
+_ANALYTICS_BOOTSTRAP_LOCK = threading.Lock()
+_ANALYTICS_BOOTSTRAP_RETRY_SECONDS = 30
+_ANALYTICS_BOOTSTRAP_ENABLED = os.environ.get(
+    "ENABLE_ANALYTICS_BOOTSTRAP",
+    "true" if os.environ.get("RAILWAY_ENVIRONMENT") else "false"
+).lower() == "true"
+_analytics_bootstrap_state = {
+    "ready": False,
+    "last_attempt": 0.0
+}
+
+
+def ensure_analytics_bootstrap_once(force=False):
+    """Try to create analytics tables once per retry window before handling traffic."""
+    if _analytics_bootstrap_state["ready"]:
+        return True
+
+    now = time.time()
+    if not force and (now - _analytics_bootstrap_state["last_attempt"]) < _ANALYTICS_BOOTSTRAP_RETRY_SECONDS:
+        return False
+
+    with _ANALYTICS_BOOTSTRAP_LOCK:
+        if _analytics_bootstrap_state["ready"]:
+            return True
+
+        now = time.time()
+        if not force and (now - _analytics_bootstrap_state["last_attempt"]) < _ANALYTICS_BOOTSTRAP_RETRY_SECONDS:
+            return False
+
+        _analytics_bootstrap_state["last_attempt"] = now
+        ready = database.ensure_analytics_ready()
+        if ready:
+            _analytics_bootstrap_state["ready"] = True
+            log_event("analytics_bootstrap", status="ready")
+        else:
+            log_event("analytics_bootstrap", status="deferred")
+
+        return _analytics_bootstrap_state["ready"]
+
+
+@app.before_request
+def bootstrap_analytics_before_traffic():
+    if _ANALYTICS_BOOTSTRAP_ENABLED and not _analytics_bootstrap_state["ready"]:
+        ensure_analytics_bootstrap_once()
 
 def get_sentinel2_image(roi):
     """Obtiene la imagen Sentinel-2 más reciente y libre de nubes para la ROI."""

--- a/api/config.py
+++ b/api/config.py
@@ -17,6 +17,7 @@ Fecha: Noviembre 2025
 import os
 import logging
 import socket
+import sys
 from urllib.parse import urlparse
 
 # Cargar .env solo si existe (desarrollo local)
@@ -29,7 +30,8 @@ except ImportError:
 # Configurar logging
 logging.basicConfig(
     level=os.getenv('LOG_LEVEL', 'INFO'),
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    stream=sys.stdout
 )
 logger = logging.getLogger(__name__)
 

--- a/api/database.py
+++ b/api/database.py
@@ -130,6 +130,19 @@ def get_db_connection():
         logger.error(f"Error connecting to database: {e}")
         return None
 
+
+def ensure_analytics_ready():
+    """Eagerly bootstrap analytics tables to avoid first-request warnings."""
+    conn = get_db_connection()
+    if not conn:
+        logger.warning("Analytics bootstrap skipped because database connection is unavailable.")
+        return False
+
+    try:
+        return _ensure_analytics_tables(conn)
+    finally:
+        conn.close()
+
 def log_visit(page='/', user_agent=None, ip_hash=None):
     """Logs a page visit to metadata.page_visits."""
     conn = get_db_connection()

--- a/scripts/monitor_deploy.py
+++ b/scripts/monitor_deploy.py
@@ -116,11 +116,28 @@ def run_checks(base_url, endpoints):
     return all(result["healthy"] for result in results)
 
 
+def run_with_retries(base_url, endpoints, retries=1, retry_delay=5):
+    attempts = max(int(retries), 1)
+    last_result = False
+
+    for attempt in range(1, attempts + 1):
+        last_result = run_checks(base_url, endpoints)
+        if last_result:
+            return True
+        if attempt < attempts:
+            print(f"[!] Check failed. Retrying in {retry_delay}s ({attempt}/{attempts - 1})...")
+            time.sleep(retry_delay)
+
+    return last_result
+
+
 def build_parser():
     parser = argparse.ArgumentParser(description="Monitor GeoFeedback deployment health and observability.")
     parser.add_argument("--url", default=DEFAULT_URL, help="Base URL to monitor.")
     parser.add_argument("--interval", type=int, default=5, help="Seconds between checks in loop mode.")
     parser.add_argument("--once", action="store_true", help="Run a single monitoring cycle and exit.")
+    parser.add_argument("--retries", type=int, default=1, help="How many times to retry before failing in once mode.")
+    parser.add_argument("--retry-delay", type=int, default=5, help="Seconds to wait between retries in once mode.")
     return parser
 
 
@@ -132,9 +149,16 @@ def main():
     print("-" * 72)
     try:
         while True:
-            all_healthy = run_checks(args.url, DEFAULT_ENDPOINTS)
             if args.once:
+                all_healthy = run_with_retries(
+                    args.url,
+                    DEFAULT_ENDPOINTS,
+                    retries=args.retries,
+                    retry_delay=args.retry_delay,
+                )
                 return 0 if all_healthy else 1
+
+            all_healthy = run_checks(args.url, DEFAULT_ENDPOINTS)
             if not all_healthy:
                 print("[!] One or more checks failed.")
             print("-" * 72)

--- a/tests/test_monitor_deploy.py
+++ b/tests/test_monitor_deploy.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_DIR = os.path.join(ROOT_DIR, "scripts")
+
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import monitor_deploy  # noqa: E402
+
+
+class MonitorDeployContractTests(unittest.TestCase):
+    def test_observability_healthy_contract(self):
+        payload = {
+            "status": "healthy",
+            "critical_checks": {
+                "database": True,
+                "analytics": True,
+                "google_earth_engine": True,
+                "google_maps_key": True,
+            },
+            "analytics": {"ready": True},
+        }
+
+        healthy, reason = monitor_deploy.evaluate_response("/api/v1/observability", 200, payload)
+
+        self.assertTrue(healthy)
+        self.assertEqual(reason, "ok")
+
+    def test_observability_degraded_when_analytics_not_ready(self):
+        payload = {
+            "status": "degraded",
+            "critical_checks": {
+                "database": True,
+                "analytics": False,
+                "google_earth_engine": True,
+                "google_maps_key": True,
+            },
+            "analytics": {"ready": False},
+        }
+
+        healthy, reason = monitor_deploy.evaluate_response("/api/v1/observability", 503, payload)
+
+        self.assertFalse(healthy)
+        self.assertEqual(reason, "observability reports degraded state")
+
+    def test_stats_requires_integer_counters(self):
+        payload = {"visits": "0", "analyses": 1}
+
+        healthy, reason = monitor_deploy.evaluate_response("/api/v1/stats", 200, payload)
+
+        self.assertFalse(healthy)
+        self.assertEqual(reason, "stats payload missing integer counters")
+
+    def test_health_requires_healthy_status(self):
+        payload = {"status": "degraded"}
+
+        healthy, reason = monitor_deploy.evaluate_response("/api/v1/health", 200, payload)
+
+        self.assertFalse(healthy)
+        self.assertEqual(reason, "health payload invalid")
+
+
+class MonitorDeployRetryTests(unittest.TestCase):
+    @patch.object(monitor_deploy.time, "sleep")
+    @patch.object(monitor_deploy, "run_checks", side_effect=[False, True])
+    def test_run_with_retries_stops_after_success(self, mock_run_checks, mock_sleep):
+        healthy = monitor_deploy.run_with_retries(
+            "https://geofeedback.cl",
+            monitor_deploy.DEFAULT_ENDPOINTS,
+            retries=3,
+            retry_delay=1,
+        )
+
+        self.assertTrue(healthy)
+        self.assertEqual(mock_run_checks.call_count, 2)
+        mock_sleep.assert_called_once_with(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_public_stats_and_routes.py
+++ b/tests/test_public_stats_and_routes.py
@@ -101,6 +101,32 @@ class ObservabilityRouteTests(unittest.TestCase):
         self.assertFalse(payload["optional_checks"]["redis"])
 
 
+class AnalyticsBootstrapMiddlewareTests(unittest.TestCase):
+    def setUp(self):
+        self.client = app_module.app.test_client()
+
+    @patch.object(app_module.database, "ensure_analytics_ready", return_value=True)
+    def test_bootstrap_runs_before_request_when_enabled(self, _mock_bootstrap):
+        previous_ready = app_module._analytics_bootstrap_state["ready"]
+        previous_last_attempt = app_module._analytics_bootstrap_state["last_attempt"]
+        previous_enabled = app_module._ANALYTICS_BOOTSTRAP_ENABLED
+
+        try:
+            app_module._analytics_bootstrap_state["ready"] = False
+            app_module._analytics_bootstrap_state["last_attempt"] = 0.0
+            app_module._ANALYTICS_BOOTSTRAP_ENABLED = True
+
+            response = self.client.get("/api/v1/health")
+            self.assertEqual(response.status_code, 200)
+
+            _mock_bootstrap.assert_called_once()
+            self.assertTrue(app_module._analytics_bootstrap_state["ready"])
+        finally:
+            app_module._analytics_bootstrap_state["ready"] = previous_ready
+            app_module._analytics_bootstrap_state["last_attempt"] = previous_last_attempt
+            app_module._ANALYTICS_BOOTSTRAP_ENABLED = previous_enabled
+
+
 class RedirectRoutesTests(unittest.TestCase):
     def setUp(self):
         self.client = app_module.app.test_client()


### PR DESCRIPTION
## Summary
- harden Railway startup by bootstrapping analytics tables before traffic and normalizing logs to stdout
- add retry-aware deployment smoke monitoring and a production observability check in CI
- expand regression coverage for analytics bootstrap and deployment monitor behavior

## Validation
- python -m unittest discover -s tests -p "test_*.py" -v
- python scripts/monitor_deploy.py --url https://geofeedback.cl --once --retries 2 --retry-delay 1
- validated Railway deployment startup logs after rollout
