### PR TITLE
Fix workflow token permissions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an explicit permissions block to the CI workflow
- restrict the default GITHUB_TOKEN scope to contents: read
- resolve CodeQL alert actions/missing-workflow-permissions in .github/workflows/ci.yml

## Validation
- verified .github/workflows/ci.yml has no workspace errors
- confirmed the diff only adds permissions: contents: read
- fetched alert details via gh api to confirm the exact rule and location
